### PR TITLE
#1 Don't add empty files to generated assembly

### DIFF
--- a/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/AssembleMojo.java
+++ b/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/AssembleMojo.java
@@ -2,6 +2,7 @@ package com.backbase.oss.blimp;
 
 import static java.util.Optional.ofNullable;
 
+import com.backbase.oss.blimp.file.NonEmptyFileSelector;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -12,10 +13,10 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
-import org.codehaus.plexus.archiver.FileSet;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
+import org.codehaus.plexus.components.io.fileselectors.FileSelector;
 
 /**
  * Creates an archive containing the generated SQL files.
@@ -81,11 +82,12 @@ public class AssembleMojo extends MojoBase {
             + "." + format;
         final File archive = new File(this.project.getBuild().getDirectory(), archiveName);
         final Archiver archiver = this.archiverManager.getArchiver(archive);
-        final FileSet fileSet = DefaultFileSet
+        final DefaultFileSet fileSet = DefaultFileSet
             .fileSet(this.scriptsDirectory)
             .prefixed(this.serviceName + "/")
             .include(new String[] {SQL_FILES})
             .includeEmptyDirs(false);
+        fileSet.setFileSelectors(new FileSelector[] { new NonEmptyFileSelector() });
 
         archiver.setDestFile(archive);
         archiver.addFileSet(fileSet);

--- a/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/file/NonEmptyFileSelector.java
+++ b/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/file/NonEmptyFileSelector.java
@@ -1,0 +1,25 @@
+package com.backbase.oss.blimp.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nonnull;
+import org.codehaus.plexus.components.io.fileselectors.FileInfo;
+import org.codehaus.plexus.components.io.fileselectors.FileSelector;
+
+public class NonEmptyFileSelector implements FileSelector {
+
+    @Override
+    public boolean isSelected(@Nonnull FileInfo fileInfo) throws IOException {
+        if (!fileInfo.isFile()) {
+            return false;
+        }
+        byte[] buffer = new byte[10];
+        try (InputStream content = fileInfo.getContents()) {
+            if (content.read(buffer) <= 1) {
+                // Liquibase has generated a file containing just an empty line
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
My attempt to make liquibase not generate empty files has failed, so I decided to not include them in the assembly.

Closes #1