### PR TITLE
Makes it possible to use blimp without the formatting of blimp formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,14 @@ the initial version, so only the upgrade scripts should be generated.
 
 *User property*: `blimp.withInitialVersion`
 
+##### blimpFormattingDisabled
+
+Generates the scripts without the formatting which blimp provides.
+
+*Default*: `false`
+
+*User property*: `blimp.blimpFormattingDisabled`
+
 ### Full Configuration with default values
 
 ```xml
@@ -525,6 +533,7 @@ the initial version, so only the upgrade scripts should be generated.
                 <testChangeLogDirectory>${project.basedir}/src/test/resources</testChangeLogDirectory>
                 <testScriptsDirectory>${project.build.directory}/generated-test-resources/blimp</testScriptsDirectory>
                 <withInitialVersion>false</withInitialVersion>
+                <blimpFormattingDisabled>true</blimpFormattingDisabled>
             </configuration>
         </execution>
     </executions>

--- a/blimp-core/src/main/java/com/backbase/oss/blimp/core/AbstractBlimpConfiguration.java
+++ b/blimp-core/src/main/java/com/backbase/oss/blimp/core/AbstractBlimpConfiguration.java
@@ -6,6 +6,7 @@ import liquibase.configuration.AbstractConfigurationContainer;
 
 public abstract class AbstractBlimpConfiguration extends AbstractConfigurationContainer {
     public static final String ENABLED = "enabled";
+    public static final String BLIMP_FORMATTING_DISABLED = "blimp_formatting_disabled";
     public static final String PRIORITY = "priority";
 
     protected final String name;
@@ -28,6 +29,13 @@ public abstract class AbstractBlimpConfiguration extends AbstractConfigurationCo
             .addProperty(PRIORITY, Integer.class)
             .setDescription(format("The priority of %s", this.name))
             .setDefaultValue(priority);
+    }
+
+    protected void addBlimpFormattingDisabled(boolean formattingEnabled) {
+        getContainer()
+            .addProperty(BLIMP_FORMATTING_DISABLED, Boolean.class)
+            .setDescription(format("Blimp formatting disabled/enabled for %s", this.name))
+            .setDefaultValue(formattingEnabled);
     }
 
     public boolean isEnabled() {

--- a/blimp-format/src/main/java/com/backbase/oss/blimp/format/BlimpFormatter.java
+++ b/blimp-format/src/main/java/com/backbase/oss/blimp/format/BlimpFormatter.java
@@ -1,6 +1,7 @@
 package com.backbase.oss.blimp.format;
 
 
+import static com.backbase.oss.blimp.core.AbstractBlimpConfiguration.BLIMP_FORMATTING_DISABLED;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
@@ -35,8 +36,10 @@ public class BlimpFormatter extends AbstractSqlGenerator {
 
     @Override
     public Sql[] generateSql(SqlStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        boolean blimpFormattingDisabled = getConfiguration().getProperty(BLIMP_FORMATTING_DISABLED)
+            .getValue(Boolean.class);
         return stream(sqlGeneratorChain.generateSql(statement, database))
-            .map(this::formatSQL)
+            .map(s -> blimpFormattingDisabled ? s : formatSQL(s))
             .toArray(Sql[]::new);
     }
 

--- a/blimp-format/src/main/java/com/backbase/oss/blimp/format/FormatterConfiguration.java
+++ b/blimp-format/src/main/java/com/backbase/oss/blimp/format/FormatterConfiguration.java
@@ -6,9 +6,16 @@ import liquibase.sqlgenerator.SqlGenerator;
 
 public class FormatterConfiguration extends AbstractBlimpConfiguration {
 
+    private static boolean blimpFormattingDisabled = false;
+
     public FormatterConfiguration() {
         super("formatter");
 
         addPriority(SqlGenerator.PRIORITY_DEFAULT + 50);
+        addBlimpFormattingDisabled(blimpFormattingDisabled);
+    }
+
+    public static void setBlimpFormattingDisabled(boolean value) {
+        blimpFormattingDisabled = value;
     }
 }

--- a/blimp-format/src/test/java/com/backbase/oss/blimp/format/BlimpFormatterTest.java
+++ b/blimp-format/src/test/java/com/backbase/oss/blimp/format/BlimpFormatterTest.java
@@ -61,7 +61,7 @@ class BlimpFormatterTest {
     }
 
     @Test
-    void formatterDisabled() throws Exception {
+    void blimpDisabled() throws Exception {
         LiquibaseConfiguration.getInstance().getConfiguration(FormatterConfiguration.class)
             .setValue(AbstractBlimpConfiguration.ENABLED, false);
 
@@ -72,6 +72,21 @@ class BlimpFormatterTest {
         }
 
         assertThat(this.output.toString()).doesNotContain(this.expected);
+    }
+
+    @Test
+    void blimpFormattingDisabled() throws Exception {
+        LiquibaseConfiguration.getInstance().getConfiguration(FormatterConfiguration.class)
+            .setValue(AbstractBlimpConfiguration.BLIMP_FORMATTING_DISABLED, true);
+
+        try (final Liquibase liquibase = new Liquibase("product-db/changelog/db.changelog-persistence.xml",
+            this.accessor, this.database)) {
+
+            liquibase.update("", new Contexts(""), new LabelExpression(""), this.output);
+        }
+        String expected = IOUtils.toString(
+            getClass().getResourceAsStream("/generate/expected_without_blimp_formatting.sql"));
+        assertThat(this.output.toString()).contains(expected);
     }
 
     @Test

--- a/blimp-format/src/test/resources/generate/expected_without_blimp_formatting.sql
+++ b/blimp-format/src/test/resources/generate/expected_without_blimp_formatting.sql
@@ -1,0 +1,1 @@
+CREATE TABLE product (id BIGINT AUTO_INCREMENT NOT NULL, create_date datetime NOT NULL COMMENT 'The date when the product was created', name VARCHAR(255) NOT NULL COMMENT 'The name of the product', weight SMALLINT NULL COMMENT 'The weight of the product in kgs', CONSTRAINT pk_product PRIMARY KEY (id)) COMMENT='Table to store the Products from our store';

--- a/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/AbstractGenerateMojo.java
+++ b/blimp-maven-plugin/src/main/java/com/backbase/oss/blimp/AbstractGenerateMojo.java
@@ -5,6 +5,7 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 
 import com.backbase.oss.blimp.core.PropertiesConfigProvider;
+import com.backbase.oss.blimp.format.FormatterConfiguration;
 import com.backbase.oss.blimp.liquibase.LiquibaseGenerator;
 import com.backbase.oss.blimp.liquibase.LiquibaseGenerator.LiquibaseGeneratorBuilder;
 import java.io.File;
@@ -120,6 +121,12 @@ public abstract class AbstractGenerateMojo extends MojoBase {
         required = true, readonly = true)
     private File cacheDirectory;
 
+    /**
+     * The configuration which is used to show that no formatting is needed.
+     */
+    @Parameter(property = "blimp.blimpFormattingDisabled", defaultValue = "false")
+    private boolean blimpFormattingDisabled;
+
     @Override
     protected void doExecute() throws Exception {
         LogService.setLoggerFactory(new MavenLoggerFactory(getLog()));
@@ -179,6 +186,8 @@ public abstract class AbstractGenerateMojo extends MojoBase {
         }
 
         addOutputResource();
+
+        FormatterConfiguration.setBlimpFormattingDisabled(blimpFormattingDisabled);
 
         return engine.toBuilder()
             .strategy(gv.getStrategy())


### PR DESCRIPTION
When using blimp to generate sql scripts from the `liquibase` change sets, it produces script files with lots of extra empty lines in between.
Most of the time the extra formatting by blimp does not seem necessary as the scripts, which liquibase is generated, are already well formatted.
This PR makes it possible to use blimp without that extra layer of formatting which blimp provides through BlimpFormatter.
